### PR TITLE
🐛 fix(venv): seed pip into hook environments

### DIFF
--- a/src/pre_commit_uv/__init__.py
+++ b/src/pre_commit_uv/__init__.py
@@ -74,6 +74,7 @@ def _new_main(argv: list[str] | None = None) -> int:
             "--project",
             project_root_dir,
             "venv",
+            "--seed",
             environment_dir(prefix, python.ENVIRONMENT_DIR, version),
             "-p",
             py,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -68,6 +68,21 @@ def test_install(git_repo: Path, caplog: pytest.LogCaptureFixture, monkeypatch: 
     ]
 
 
+def test_install_seeds_pip(git_repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("FORCE_PRE_COMMIT_UV_PATCH", "1")
+
+    import pre_commit_uv  # noqa: PLC0415
+
+    pre_commit_uv._patch()  # noqa: SLF001
+    main.main(["install-hooks", "-c", str(git_repo / precommit_file)])
+
+    env_dirs = list((git_repo / "store").rglob("py_env-*"))
+    assert env_dirs, "expected at least one hook environment"
+    py = next((env_dirs[0] / "bin").glob("python*"))
+    result = check_output([str(py), "-c", "import pip"], encoding="utf-8")
+    assert not result
+
+
 test_install_with_uv_config_cases: list[tuple[str, str]] = [
     (
         "pyproject.toml",


### PR DESCRIPTION
`uv venv` does not install `pip` into virtual environments by default, unlike `python -m venv`. Hooks such as `mypy` that internally call `python -m pip install` at runtime (e.g. to fetch missing type stubs) fail with `No module named pip` in the hook environment. This affects CI environments where pre-commit-uv manages hook installation.

Passing `--seed` to `uv venv` restores `pip` and `setuptools` availability in the created environment, matching standard `venv` behavior and fixing any hook that depends on `pip` at runtime.

Fixes #61