### PR TITLE
🔧 chore: batch dependency updates weekly on Tuesday

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,4 +3,9 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "tuesday"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Dependabot opened a separate pull request for every bump here, which turned routine maintenance into a stream of near-identical reviews. 🔁

`.github/dependabot.yaml` now runs weekly on Tuesday with a catch-all `groups` entry per ecosystem, so one pull request carries the week's bumps. The other projects I maintain are moving to the same schedule.
